### PR TITLE
[BSP][CHARGE] Correctly unregister usb_psy

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smb2.c
+++ b/drivers/power/supply/qcom/qpnp-smb2.c
@@ -2582,7 +2582,7 @@ static int smb2_remove(struct platform_device *pdev)
 
 /* david.liu@bsp, 20170330 Fix system crash */
 	if (chg->usb_psy)
-		power_supply_unregister(chg->batt_psy);
+		power_supply_unregister(chg->usb_psy);
 	if (chg->batt_psy)
 		power_supply_unregister(chg->batt_psy);
 	if (chg->vconn_vreg && chg->vconn_vreg->rdev)


### PR DESCRIPTION
* fixes unregistering batt_psy after checking usb_psy